### PR TITLE
Add IPV6 Toggle for netwok options

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -11,251 +11,248 @@ import (
 	"github.com/spf13/cobra"
 )
 
-
-
 type (
-    // This struct covers the entire application configuration
+	// This struct covers the entire application configuration
 	Config struct {
-		Server serverConfig `koanf:"server"`
-        Logging loggingConfig `koanf:"logging"`
-        Cluster clusterConfig `koanf:"cluster"`
-        TimeoutWatcher timeoutWatcherConfig `koanf:"timeout_watcher"`
-        Recast recastConfig `koanf:"recast"`
-        Telemetry telemetryConfig `koanf:"telemetry"`
-        Staller httpStallerConfig `koanf:"staller"`
-    }
+		Server         serverConfig         `koanf:"server"`
+		Logging        loggingConfig        `koanf:"logging"`
+		Cluster        clusterConfig        `koanf:"cluster"`
+		TimeoutWatcher timeoutWatcherConfig `koanf:"timeout_watcher"`
+		Recast         recastConfig         `koanf:"recast"`
+		Telemetry      telemetryConfig      `koanf:"telemetry"`
+		Staller        httpStallerConfig    `koanf:"staller"`
+	}
 
-    // Server specific configuration
-   	serverConfig struct {
+	// Server specific configuration
+	serverConfig struct {
 		// Server port to listen on
 		Port int `koanf:"port" validate:"required,min=1,max=65535"`
 
-        // Server host to listen on
+		// Server host to listen on
 		Host string `koanf:"host" validate:"required"`
+
+		// Network stack to use (tcp, tcp4, tcp6)
+		Network string `koanf:"network" validate:"required,oneof=tcp tcp4 tcp6"`
 	}
 
-    // Cluster specific configuration
-    clusterConfig struct {
-        // If cluster mode is enabled (Nodes will become aware of each other)
-        Enabled bool `koanf:"enabled"`
+	// Cluster specific configuration
+	clusterConfig struct {
+		// If cluster mode is enabled (Nodes will become aware of each other)
+		Enabled bool `koanf:"enabled"`
 
-        // The mode for the cluster to use. The modes are as follows:
-        // fargate_ecs - This mode is for when the application is running in AWS Fargate
-        //               Ip addresses are supplied by the AWS v4 Metadata endpoint so no other IP addresses are needed
-        // lan         - This mode is for when the application is running on a local network (See https://github.com/hashicorp/memberlist/blob/8ddac568337bd6b77df1aed75317a52f8b930e83/config.go#L296 for more info)
-        // wan         - This mode is for when the application is running on a public network (See https://github.com/hashicorp/memberlist/blob/8ddac568337bd6b77df1aed75317a52f8b930e83/config.go#L340C6-L340C22 for more info)
-        Mode string `koanf:"mode" validate:"required_if=Enabled true,omitempty,oneof=fargate_ecs lan wan"`
+		// The mode for the cluster to use. The modes are as follows:
+		// fargate_ecs - This mode is for when the application is running in AWS Fargate
+		//               Ip addresses are supplied by the AWS v4 Metadata endpoint so no other IP addresses are needed
+		// lan         - This mode is for when the application is running on a local network (See https://github.com/hashicorp/memberlist/blob/8ddac568337bd6b77df1aed75317a52f8b930e83/config.go#L296 for more info)
+		// wan         - This mode is for when the application is running on a public network (See https://github.com/hashicorp/memberlist/blob/8ddac568337bd6b77df1aed75317a52f8b930e83/config.go#L340C6-L340C22 for more info)
+		Mode string `koanf:"mode" validate:"required_if=Enabled true,omitempty,oneof=fargate_ecs lan wan"`
 
-        // The bind address for the cluster to listen on
-        BindPort int `koanf:"bind_port" validate:"required_if=Enabled true,omitempty,min=1,max=65535"`
+		// The bind address for the cluster to listen on
+		BindPort int `koanf:"bind_port" validate:"required_if=Enabled true,omitempty,min=1,max=65535"`
 
-        // Known Peers
-        KnownPeerIps []string `koanf:"known_peer_ips" validate:"required_if=Mode lan Mode wan,omitempty"`
+		// Known Peers
+		KnownPeerIps []string `koanf:"known_peer_ips" validate:"required_if=Mode lan Mode wan,omitempty"`
 
-        // Host Ip Address
-        // Advertisement IP Address for this node to use against other nodes in the cluster
-        AdvertiseIp string `koanf:"advertise_ip" validate:"required_if=Mode lan Mode wan,omitempty,ipv4"`
+		// Host Ip Address
+		// Advertisement IP Address for this node to use against other nodes in the cluster
+		AdvertiseIp string `koanf:"advertise_ip" validate:"required_if=Mode lan Mode wan,omitempty,ipv4"`
 
-        // Enable member list logging output
-        EnableLogging bool `koanf:"enable_logging"`
+		// Enable member list logging output
+		EnableLogging bool `koanf:"enable_logging"`
 
-        // Number of connection attempts to make to other nodes in the cluster before giving up
-        ConnectionAttempts int `koanf:"connection_attempts" validate:"min=1"`
+		// Number of connection attempts to make to other nodes in the cluster before giving up
+		ConnectionAttempts int `koanf:"connection_attempts" validate:"min=1"`
 
-        // The timeout for each connection attempt in seconds
-        ConnectionTimeout int `koanf:"connection_timeout_secs" validate:"min=1"`
+		// The timeout for each connection attempt in seconds
+		ConnectionTimeout int `koanf:"connection_timeout_secs" validate:"min=1"`
+	}
 
-    }
+	// Logging specific configuration
+	loggingConfig struct {
+		// Logging level
+		Level string `koanf:"level"`
+	}
 
-    // Logging specific configuration
-    loggingConfig struct {
-        // Logging level
-        Level string `koanf:"level"`
-    }
+	// Timeout watcher specific configuration
+	timeoutWatcherConfig struct {
+		// If the timeout watcher is enabled. In the event that this is disabled
+		// an infinite timeout will be given to all requests
+		Enabled bool `koanf:"enabled"`
 
-    // Timeout watcher specific configuration
-    timeoutWatcherConfig struct {
-        // If the timeout watcher is enabled. In the event that this is disabled
-        // an infinite timeout will be given to all requests
-        Enabled bool `koanf:"enabled"`
-
-        // The number of requests that are allowed before things begin slowing down
+		// The number of requests that are allowed before things begin slowing down
 		GraceRequests int
 
-         // The TTL (in seconds) for the hot cache pool
-        CacheHotPoolTTL int `koanf:"hot_pool_ttl_sec" validate:"omitempty,min=1"`
-        
-        // The TTL (in seconds) for the cold cache pool
-        CacheColdPoolTTL int `koanf:"cold_pool_ttl_sec" validate:"omitempty,min=1"`
+		// The TTL (in seconds) for the hot cache pool
+		CacheHotPoolTTL int `koanf:"hot_pool_ttl_sec" validate:"omitempty,min=1"`
 
-        // The maximum amount of time a given IP can be hanging before we consider the IP
-        // to be vulnerable to hanging forever on a request. Any ips that get past this threshold
-        // will always be given the longest timeout
-        InstantCommitThreshold int `koanf:"instant_commit_threshold_ms" validate:"omitempty,min=1"` 
-        
-        // The upper bound for increasing timeouts in milliseconds. Once the timeout increases to reach this bound we will hang forever.
-        UpperTimeoutBound int `koanf:"upper_timeout_bound_ms" validate:"min=1"`
+		// The TTL (in seconds) for the cold cache pool
+		CacheColdPoolTTL int `koanf:"cold_pool_ttl_sec" validate:"omitempty,min=1"`
 
-        // The smallest timeout we will ever give im milliseconds
-        LowerTimeoutBound int `koanf:"lower_timeout_bound_ms" validate:"min=1"`
+		// The maximum amount of time a given IP can be hanging before we consider the IP
+		// to be vulnerable to hanging forever on a request. Any ips that get past this threshold
+		// will always be given the longest timeout
+		InstantCommitThreshold int `koanf:"instant_commit_threshold_ms" validate:"omitempty,min=1"`
 
-        // The timeout given by requests that are in the grace set of requests in milliseconds 
-        GraceTimeout int `koanf:"grace_timeout_ms" validate:"omitempty,min=1"`
+		// The upper bound for increasing timeouts in milliseconds. Once the timeout increases to reach this bound we will hang forever.
+		UpperTimeoutBound int `koanf:"upper_timeout_bound_ms" validate:"min=1"`
 
-        // The amount of time to wait when hanging an IP "forever"
-        LongestTimeout int `koanf:"longest_timeout_ms" validate:"omitempty,min=1"`
+		// The smallest timeout we will ever give im milliseconds
+		LowerTimeoutBound int `koanf:"lower_timeout_bound_ms" validate:"min=1"`
 
-        // The increment we will increase timeouts by for requests with timeouts larger than 30 seconds
-        TimeoutOverThirtyIncrement int `koanf:"timeout_over_thirty_increment_ms" validate:"omitempty,min=1"`
+		// The timeout given by requests that are in the grace set of requests in milliseconds
+		GraceTimeout int `koanf:"grace_timeout_ms" validate:"omitempty,min=1"`
 
-        // The increment we will increase timeouts by for requests with timeouts smaller than 30 seconds
-        TimeoutSubThirtyIncrement int `koanf:"timeout_sub_thirty_increment_ms" validate:"omitempty,min=1"`
+		// The amount of time to wait when hanging an IP "forever"
+		LongestTimeout int `koanf:"longest_timeout_ms" validate:"omitempty,min=1"`
 
-        // The increment we will increase timeouts by for requests with timeouts smaller than 10 seconds
-        TimeoutSubTenIncrement int `koanf:"timeout_sub_ten_increment_ms" validate:"omitempty,min=1"`
-        
-        // The number of samples to take to detect a timeout
-        DetectionSampleSize 	int `koanf:"sample_size" validate:"omitempty,min=2"`
+		// The increment we will increase timeouts by for requests with timeouts larger than 30 seconds
+		TimeoutOverThirtyIncrement int `koanf:"timeout_over_thirty_increment_ms" validate:"omitempty,min=1"`
 
-        // How standard deviation of the last "sample_size" requests to take before committing to a timeout
-        DetectionSampleDeviation int `koanf:"sample_deviation_ms" validate:"omitempty,min=1"`
+		// The increment we will increase timeouts by for requests with timeouts smaller than 30 seconds
+		TimeoutSubThirtyIncrement int `koanf:"timeout_sub_thirty_increment_ms" validate:"omitempty,min=1"`
+
+		// The increment we will increase timeouts by for requests with timeouts smaller than 10 seconds
+		TimeoutSubTenIncrement int `koanf:"timeout_sub_ten_increment_ms" validate:"omitempty,min=1"`
+
+		// The number of samples to take to detect a timeout
+		DetectionSampleSize int `koanf:"sample_size" validate:"omitempty,min=2"`
+
+		// How standard deviation of the last "sample_size" requests to take before committing to a timeout
+		DetectionSampleDeviation int `koanf:"sample_deviation_ms" validate:"omitempty,min=1"`
 	}
 
-    // Telemetry specific configuration
-    telemetryConfig struct {
-        // If telemetry is enabled or not
-        Enabled bool `koanf:"enabled"`
+	// Telemetry specific configuration
+	telemetryConfig struct {
+		// If telemetry is enabled or not
+		Enabled bool `koanf:"enabled"`
 
-        // The node name for identifying the said node
-        NodeName string `koanf:"node_name" validate:"omitempty"`
+		// The node name for identifying the said node
+		NodeName string `koanf:"node_name" validate:"omitempty"`
 
-        // Using with push gateway
-        PushGateway telemetryPushGatewayConfig `koanf:"push_gateway"`
-        
-        // Prometheus metrics
-        Metrics telemetryMetricsConfig `koanf:"metrics"`
+		// Using with push gateway
+		PushGateway telemetryPushGatewayConfig `koanf:"push_gateway"`
 
-        // Prometheus configuration
-        Prometheus telemetryPrometheusConfig `koanf:"prometheus"`
-    }
+		// Prometheus metrics
+		Metrics telemetryMetricsConfig `koanf:"metrics"`
 
-    // Configuration related to the telemetry prometheus
-    telemetryPrometheusConfig struct {
-        // If the prometheus server is enabled
-        Enabled bool `koanf:"enabled"`
+		// Prometheus configuration
+		Prometheus telemetryPrometheusConfig `koanf:"prometheus"`
+	}
 
-        // The port for the prometheus collection endpoint
-        Port int `koanf:"prometheus_port" validate:"required,min=1,max=65535"`
+	// Configuration related to the telemetry prometheus
+	telemetryPrometheusConfig struct {
+		// If the prometheus server is enabled
+		Enabled bool `koanf:"enabled"`
 
-        // The path for the prometheus endpoint
-        Path string `koanf:"prometheus_path" validate:"required"`
-    }
+		// The port for the prometheus collection endpoint
+		Port int `koanf:"prometheus_port" validate:"required,min=1,max=65535"`
 
-    // Configuration related to the telemetry push gateway
-    telemetryPushGatewayConfig struct {
-        Enabled bool `koanf:"enabled"`
+		// The path for the prometheus endpoint
+		Path string `koanf:"prometheus_path" validate:"required"`
+	}
 
-        // The address of the push gateway
-        Endpoint string `koanf:"endpoint" validate:"required_if=Enabled true,omitempty"`
+	// Configuration related to the telemetry push gateway
+	telemetryPushGatewayConfig struct {
+		Enabled bool `koanf:"enabled"`
 
-        // The username for the push gateway (For basic auth)
-        Username string `koanf:"username" validate:"required_with=Password"`
+		// The address of the push gateway
+		Endpoint string `koanf:"endpoint" validate:"required_if=Enabled true,omitempty"`
 
-        // The password for the push gateway (For basic auth)
-        Password string `koanf:"password" validate:"required_with=Username"`
+		// The username for the push gateway (For basic auth)
+		Username string `koanf:"username" validate:"required_with=Password"`
 
-        // The interval in seconds to push metrics to the push gateway
-        // Default: 60
-        PushIntervalSecs int `koanf:"push_interval_secs" validate:"omitempty,min=1"`
-    }
+		// The password for the push gateway (For basic auth)
+		Password string `koanf:"password" validate:"required_with=Username"`
 
-    // Configuration related to the prometheus metrics
-    telemetryMetricsConfig struct {
-        // If prometheus should expose the secrets generated metric
-        TrackSecretsGenerated bool `koanf:"track_secrets_generated"`
+		// The interval in seconds to push metrics to the push gateway
+		// Default: 60
+		PushIntervalSecs int `koanf:"push_interval_secs" validate:"omitempty,min=1"`
+	}
 
-        // If prometheus should expose the time wasted metric
-        TrackTimeWasted bool `koanf:"track_time_wasted"`
-    }
+	// Configuration related to the prometheus metrics
+	telemetryMetricsConfig struct {
+		// If prometheus should expose the secrets generated metric
+		TrackSecretsGenerated bool `koanf:"track_secrets_generated"`
 
-    // Configuration related to "recasting" a process in which the node will shutdown in the event that 
-    // there has been no significant amount of time wasted by the node
-    recastConfig struct {
-        // If the recast system is enabled or not
-        Enabled bool `koanf:"enabled"`
+		// If prometheus should expose the time wasted metric
+		TrackTimeWasted bool `koanf:"track_time_wasted"`
+	}
 
-        // The minimum interval in minutes to wait before recasting
-        // Default: 30
-        MinimumRecastIntervalMin int `koanf:"minimum_recast_interval_min" validate:"omitempty,min=1"`
+	// Configuration related to "recasting" a process in which the node will shutdown in the event that
+	// there has been no significant amount of time wasted by the node
+	recastConfig struct {
+		// If the recast system is enabled or not
+		Enabled bool `koanf:"enabled"`
 
-        // The maximum interval in minutes to wait before recasting
-        // Default: 120
-        MaximumRecastIntervalMin int `koanf:"maximum_recast_interval_min" validate:"omitempty,min=1"`
+		// The minimum interval in minutes to wait before recasting
+		// Default: 30
+		MinimumRecastIntervalMin int `koanf:"minimum_recast_interval_min" validate:"omitempty,min=1"`
 
-        // The ratio of time wasted to time spent. If the ratio is less than this value then the node should recast
-        // Default: 0.05
-        TimeWastedRatio float64 `koanf:"time_wasted_ratio" validate:"omitempty,min=0,max=1"`
-    }
+		// The maximum interval in minutes to wait before recasting
+		// Default: 120
+		MaximumRecastIntervalMin int `koanf:"maximum_recast_interval_min" validate:"omitempty,min=1"`
 
-    httpStallerConfig struct {
-        // The maximum number of connections that can be made to the pot at any given time
-        MaximumConnections int `koanf:"maximum_connections" validate:"required,min=1"`
+		// The ratio of time wasted to time spent. If the ratio is less than this value then the node should recast
+		// Default: 0.05
+		TimeWastedRatio float64 `koanf:"time_wasted_ratio" validate:"omitempty,min=0,max=1"`
+	}
 
-        // The transfer rate for the staller (bytes per second)
-        BytesPerSecond int `koanf:"bytes_per_second" validate:"omitempty,min=1"`
-    }
+	httpStallerConfig struct {
+		// The maximum number of connections that can be made to the pot at any given time
+		MaximumConnections int `koanf:"maximum_connections" validate:"required,min=1"`
+
+		// The transfer rate for the staller (bytes per second)
+		BytesPerSecond int `koanf:"bytes_per_second" validate:"omitempty,min=1"`
+	}
 )
 
 func NewConfig(cmd *cobra.Command) (*Config, error) {
 
-    k := koanf.New(".")
+	k := koanf.New(".")
 
-
-    // Load the default configuration
+	// Load the default configuration
 	if err := k.Load(structs.Provider(defaultConfig, "koanf"), nil); err != nil {
 		return nil, err
 	}
 
-    if err:= loadConfigFile(k, cmd); err != nil {
-        return nil, err
-    }
+	if err := loadConfigFile(k, cmd); err != nil {
+		return nil, err
+	}
 
-    // Override the default configuration with values given by the flags
-    k = writeFlagValues(k, cmd)
+	// Override the default configuration with values given by the flags
+	k = writeFlagValues(k, cmd)
 
-    // Write environment variables to the configuration
-    err := k.Load(env.ProviderWithValue("GOPOT__", ".", func(s string, v string) (string, interface{}) {
-        key := strings.Replace(strings.ToLower(strings.TrimPrefix(s, "GOPOT__")), "__", ".", -1)
-        if v == "true" || v == "false" {
-            fmt.Println(key, v == "true")
-            return key, v == "true"
-        }
+	// Write environment variables to the configuration
+	err := k.Load(env.ProviderWithValue("GOPOT__", ".", func(s string, v string) (string, interface{}) {
+		key := strings.Replace(strings.ToLower(strings.TrimPrefix(s, "GOPOT__")), "__", ".", -1)
+		if v == "true" || v == "false" {
+			fmt.Println(key, v == "true")
+			return key, v == "true"
+		}
 
-        return key, v
+		return key, v
 	}), nil)
 
-    if err != nil {
-        return nil, err
-    }
-    
+	if err != nil {
+		return nil, err
+	}
 
-    
-    // Handle special cases
-    if k.Get("cluster.known_peer_ips") != "" {
-        k.Set("cluster.known_peer_ips", strings.Split(k.String("cluster.known_peer_ips"), ","))
-    } else {
-        k.Set("cluster.known_peer_ips", []string{})
-    }
+	// Handle special cases
+	if k.Get("cluster.known_peer_ips") != "" {
+		k.Set("cluster.known_peer_ips", strings.Split(k.String("cluster.known_peer_ips"), ","))
+	} else {
+		k.Set("cluster.known_peer_ips", []string{})
+	}
 
 	var cfg *Config
 	if err := k.UnmarshalWithConf("", &cfg, koanf.UnmarshalConf{Tag: "koanf"}); err != nil {
 		return nil, err
 	}
 
-    validator := validate.New()
-    if err := validator.Struct(cfg); err != nil {
-        return nil, err
-    }
+	validator := validate.New()
+	if err := validator.Struct(cfg); err != nil {
+		return nil, err
+	}
 
 	return cfg, nil
 }

--- a/config/default.go
+++ b/config/default.go
@@ -5,76 +5,77 @@ import "go.uber.org/zap/zapcore"
 // Default configuration values for the application
 var defaultConfig = Config{
 	Server: serverConfig{
-		Port: 8080,
-		Host: "127.0.0.1",
+		Port:    8080,
+		Host:    "127.0.0.1",
+		Network: "tcp4",
 	},
-    Logging: loggingConfig {
-        Level: zapcore.InfoLevel.String(),
-    },
-    Cluster: clusterConfig {
-        Enabled: false,
-        Mode: "lan",
-        ConnectionTimeout: 5,
-        ConnectionAttempts: 5,
-        EnableLogging: false,
-        BindPort: 7946,
-    },
-    TimeoutWatcher: timeoutWatcherConfig {
-        Enabled: true,
-        
-        // Threaholds
-        InstantCommitThreshold: 180 * 1000, // 3 minutes
-        UpperTimeoutBound: 60 * 1000, // 1 minute
-        LowerTimeoutBound:  1000, // 1 second
+	Logging: loggingConfig{
+		Level: zapcore.InfoLevel.String(),
+	},
+	Cluster: clusterConfig{
+		Enabled:            false,
+		Mode:               "lan",
+		ConnectionTimeout:  5,
+		ConnectionAttempts: 5,
+		EnableLogging:      false,
+		BindPort:           7946,
+	},
+	TimeoutWatcher: timeoutWatcherConfig{
+		Enabled: true,
 
-        // Grace Periods
-        GraceRequests: 3,
-        GraceTimeout:  100, // 100ms
+		// Threaholds
+		InstantCommitThreshold: 180 * 1000, // 3 minutes
+		UpperTimeoutBound:      60 * 1000,  // 1 minute
+		LowerTimeoutBound:      1000,       // 1 second
 
-        // Timeouts
-        LongestTimeout: 7 * 24 * 60 * 60 * 1000, // 7 days
+		// Grace Periods
+		GraceRequests: 3,
+		GraceTimeout:  100, // 100ms
 
-        // Increments
-        TimeoutOverThirtyIncrement: 10 * 1000, // 10 seconds
-        TimeoutSubThirtyIncrement: 5 * 1000, // 5 seconds
-        TimeoutSubTenIncrement: 2 * 1000, // 1 second
+		// Timeouts
+		LongestTimeout: 7 * 24 * 60 * 60 * 1000, // 7 days
 
-        // Detection
-        DetectionSampleSize: 3,
-        DetectionSampleDeviation: 1000, // 1 second
+		// Increments
+		TimeoutOverThirtyIncrement: 10 * 1000, // 10 seconds
+		TimeoutSubThirtyIncrement:  5 * 1000,  // 5 seconds
+		TimeoutSubTenIncrement:     2 * 1000,  // 1 second
 
-        // Cache TTLs
-        CacheHotPoolTTL: 60 * 60, // 1 hour
-        CacheColdPoolTTL: 60 * 60 * 48, // 2 days
-    },
-    Telemetry: telemetryConfig {
-        Enabled: true,
-        NodeName: "go-pot",
-        PushGateway: telemetryPushGatewayConfig{
-            Enabled: false,
-            PushIntervalSecs: 60,
-            Endpoint: "",
-            Username: "",
-            Password: "",
-        },
-        Prometheus: telemetryPrometheusConfig{
-            Enabled: false,
-            Port: 9001,
-            Path: "/metrics",
-        },
-        Metrics: telemetryMetricsConfig{
-            TrackSecretsGenerated: true,
-            TrackTimeWasted: true,
-        },
-    },
-    Recast: recastConfig{
-        Enabled: false,
-        MinimumRecastIntervalMin: 30,
-        MaximumRecastIntervalMin: 120,
-        TimeWastedRatio: 0.05,
-    },
-    Staller: httpStallerConfig{
-        MaximumConnections: 200,
-        BytesPerSecond: 8,
-    },
+		// Detection
+		DetectionSampleSize:      3,
+		DetectionSampleDeviation: 1000, // 1 second
+
+		// Cache TTLs
+		CacheHotPoolTTL:  60 * 60,      // 1 hour
+		CacheColdPoolTTL: 60 * 60 * 48, // 2 days
+	},
+	Telemetry: telemetryConfig{
+		Enabled:  true,
+		NodeName: "go-pot",
+		PushGateway: telemetryPushGatewayConfig{
+			Enabled:          false,
+			PushIntervalSecs: 60,
+			Endpoint:         "",
+			Username:         "",
+			Password:         "",
+		},
+		Prometheus: telemetryPrometheusConfig{
+			Enabled: false,
+			Port:    9001,
+			Path:    "/metrics",
+		},
+		Metrics: telemetryMetricsConfig{
+			TrackSecretsGenerated: true,
+			TrackTimeWasted:       true,
+		},
+	},
+	Recast: recastConfig{
+		Enabled:                  false,
+		MinimumRecastIntervalMin: 30,
+		MaximumRecastIntervalMin: 120,
+		TimeWastedRatio:          0.05,
+	},
+	Staller: httpStallerConfig{
+		MaximumConnections: 200,
+		BytesPerSecond:     8,
+	},
 }

--- a/config/flags.go
+++ b/config/flags.go
@@ -9,124 +9,131 @@ import (
 )
 
 type flagConfig struct {
-	flagName string
-	configKey string
-	description string
-	configType string
+	flagName     string
+	configKey    string
+	description  string
+	configType   string
 	defaultValue interface{}
 }
 
 var flagsToConfigMap = map[string]flagConfig{
 	"port": {
-		flagName: "port",
-		configKey: "server.port",
-		description: "The port for the honeypot to listen on.",
-		configType: "int",
+		flagName:     "port",
+		configKey:    "server.port",
+		description:  "The port for the honeypot to listen on.",
+		configType:   "int",
 		defaultValue: defaultConfig.Server.Port,
 	},
 	"host": {
-		flagName: "host",
-		configKey: "server.host",
-		description: "The host for the honeypot to listen on.",
-		configType: "string",
+		flagName:     "host",
+		configKey:    "server.host",
+		description:  "The host for the honeypot to listen on.",
+		configType:   "string",
 		defaultValue: defaultConfig.Server.Host,
 	},
+	"network": {
+		flagName:     "network",
+		configKey:    "server.network",
+		description:  "The network stack to use (tcp, tcp4, tcp6).",
+		configType:   "string",
+		defaultValue: defaultConfig.Server.Network,
+	},
 	"cluster-mode-enabled": {
-		flagName: "cluster-mode-enabled",
-		configKey: "cluster.enabled",
-		description: "Enable cluster mode for connectivity with other honeypots.",
-		configType: "bool",
+		flagName:     "cluster-mode-enabled",
+		configKey:    "cluster.enabled",
+		description:  "Enable cluster mode for connectivity with other honeypots.",
+		configType:   "bool",
 		defaultValue: defaultConfig.Cluster.Enabled,
 	},
 	"cluster-advertise-ip": {
-		flagName: "cluster-advertise-ip",
-		configKey: "cluster.advertise_ip",
-		description: "The IP address to advertise to other honeypots in the cluster.",
-		configType: "string",
+		flagName:     "cluster-advertise-ip",
+		configKey:    "cluster.advertise_ip",
+		description:  "The IP address to advertise to other honeypots in the cluster.",
+		configType:   "string",
 		defaultValue: defaultConfig.Cluster.AdvertiseIp,
 	},
 	"cluster-known-peers": {
-		flagName: "cluster-known-peers",
-		configKey: "cluster.known_peers",
-		description: "A comma separated list of known peers to connect to.",
-		configType: "string",
+		flagName:     "cluster-known-peers",
+		configKey:    "cluster.known_peers",
+		description:  "A comma separated list of known peers to connect to.",
+		configType:   "string",
 		defaultValue: "",
 	},
 	"cluster-port": {
-		flagName: "cluster-port",
-		configKey: "cluster.bind_port",
-		description: "The port for the honeypot to listen on for cluster communication. [This port should not be exposed to the internet.]",
-		configType: "int",
+		flagName:     "cluster-port",
+		configKey:    "cluster.bind_port",
+		description:  "The port for the honeypot to listen on for cluster communication. [This port should not be exposed to the internet.]",
+		configType:   "int",
 		defaultValue: defaultConfig.Cluster.BindPort,
 	},
 	"cluster-logging-enabled": {
-		flagName: "cluster-logging-enabled",
-		configKey: "cluster.enable_logging",
-		description: "Enable cluster communication logging. (Useful for debugging cluster connectivity issues)",
-		configType: "bool",
+		flagName:     "cluster-logging-enabled",
+		configKey:    "cluster.enable_logging",
+		description:  "Enable cluster communication logging. (Useful for debugging cluster connectivity issues)",
+		configType:   "bool",
 		defaultValue: defaultConfig.Cluster.EnableLogging,
 	},
 	"telemetry-name": {
-		flagName: "telemetry-name",
-		configKey: "telemetry.node_name",
-		description: "The telemetry node name.",
-		configType: "string",
+		flagName:     "telemetry-name",
+		configKey:    "telemetry.node_name",
+		description:  "The telemetry node name.",
+		configType:   "string",
 		defaultValue: defaultConfig.Telemetry.NodeName,
 	},
 	"push-gateway-enabled": {
-		flagName: "push-gateway-enabled",
-		configKey: "telemetry.push_gateway.enabled",
-		description: "Enable prometheus push gateway integration.",
-		configType: "bool",
+		flagName:     "push-gateway-enabled",
+		configKey:    "telemetry.push_gateway.enabled",
+		description:  "Enable prometheus push gateway integration.",
+		configType:   "bool",
 		defaultValue: defaultConfig.Telemetry.PushGateway.Enabled,
 	},
 	"push-gateway-url": {
-		flagName: "push-gateway-url",
-		configKey: "telemetry.push_gateway.endpoint",
-		description: "The URL for the prometheus push gateway.",
-		configType: "string",
+		flagName:     "push-gateway-url",
+		configKey:    "telemetry.push_gateway.endpoint",
+		description:  "The URL for the prometheus push gateway.",
+		configType:   "string",
 		defaultValue: defaultConfig.Telemetry.PushGateway.Endpoint,
 	},
 	"prometheus-enabled": {
-		flagName: "prometheus-enabled",
-		configKey: "telemetry.prometheus.enabled",
-		description: "Enable prometheus metrics collection endpoint.",
-		configType: "bool",
+		flagName:     "prometheus-enabled",
+		configKey:    "telemetry.prometheus.enabled",
+		description:  "Enable prometheus metrics collection endpoint.",
+		configType:   "bool",
 		defaultValue: defaultConfig.Telemetry.Prometheus.Enabled,
 	},
 	"prometheus-path": {
-		flagName: "prometheus-path",
-		configKey: "telemetry.prometheus.path",
-		description: "The path for the prometheus metrics collection endpoint.",
-		configType: "string",
+		flagName:     "prometheus-path",
+		configKey:    "telemetry.prometheus.path",
+		description:  "The path for the prometheus metrics collection endpoint.",
+		configType:   "string",
 		defaultValue: defaultConfig.Telemetry.Prometheus.Path,
 	},
 	"prometheus-port": {
-		flagName: "prometheus-port",
-		configKey: "telemetry.prometheus.port",
-		description: "The port for the prometheus metrics collection endpoint.",
-		configType: "int",
+		flagName:     "prometheus-port",
+		configKey:    "telemetry.prometheus.port",
+		description:  "The port for the prometheus metrics collection endpoint.",
+		configType:   "int",
 		defaultValue: defaultConfig.Telemetry.Prometheus.Port,
 	},
 	"recast-enabled": {
-		flagName: "recast-enabled",
-		configKey: "recast.enabled",
-		description: "Enable recast metrics collection.",
-		configType: "bool",
+		flagName:     "recast-enabled",
+		configKey:    "recast.enabled",
+		description:  "Enable recast metrics collection.",
+		configType:   "bool",
 		defaultValue: defaultConfig.Recast.Enabled,
 	},
 	"maximum-connections": {
-		flagName: "maximum-connections",
-		configKey: "staller.maximum_connections",
-		description: "The maximum number of open connections to the honeypot to allow.",
-		configType: "int",
+		flagName:     "maximum-connections",
+		configKey:    "staller.maximum_connections",
+		description:  "The maximum number of open connections to the honeypot to allow.",
+		configType:   "int",
 		defaultValue: defaultConfig.Staller.MaximumConnections,
 	},
 	"bytes-per-second": {
-		flagName: "bytes-per-second",
-		configKey: "staller.bytes_per_second",
-		description: "The number of bytes to transfer per second.",
-		configType: "int",
+		flagName:     "bytes-per-second",
+		configKey:    "staller.bytes_per_second",
+		description:  "The number of bytes to transfer per second.",
+		configType:   "int",
 		defaultValue: defaultConfig.Staller.BytesPerSecond,
 	},
 }
@@ -143,7 +150,7 @@ func BindConfigFlags(cmd *cobra.Command) *cobra.Command {
 			cmd.Flags().Bool(flag.flagName, flag.defaultValue.(bool), flag.description)
 		}
 	}
-	
+
 	return cmd
 }
 

--- a/examples/config/reference.yml
+++ b/examples/config/reference.yml
@@ -10,6 +10,10 @@ server:
   # Host for the go-pot server to listen on
   host: 127.0.0.1
 
+  network:
+    # The network stack to listen on. One of: tcp, tcp4, tcp6
+    network: "tcp4"
+
 # Configuration for logging related settings for go-pot
 logging:
   # One of: debug, info, warn, error, dpanic, panic, fatal

--- a/http/server.go
+++ b/http/server.go
@@ -16,10 +16,10 @@ import (
 
 type (
 	Server struct {
-		App *fiber.App
+		App        *fiber.App
 		ListenPort int
 		ListenHost string
-		Logger *zap.Logger
+		Logger     *zap.Logger
 
 		stallerFactory *stall.HttpStallerFactory
 	}
@@ -29,7 +29,7 @@ func NewServer(
 	lf fx.Lifecycle,
 	shutdown fx.Shutdowner,
 	cfg *config.Config,
-	logging logging.IServerLogger, 
+	logging logging.IServerLogger,
 	stallerFactory *stall.HttpStallerFactory,
 ) *Server {
 	server := &Server{
@@ -37,6 +37,7 @@ func NewServer(
 			IdleTimeout:           time.Second * 15,
 			ReduceMemoryUsage:     true,
 			DisableStartupMessage: true,
+			Network:               cfg.Server.Network,
 		}),
 
 		ListenPort: cfg.Server.Port,
@@ -65,12 +66,12 @@ func (s *Server) Start() error {
 	})
 
 	s.App.Get("/*", func(c *fiber.Ctx) error {
-		
+
 		staller, err := s.stallerFactory.FromFiberContext(c)
 		if err != nil {
 			return err
 		}
-		
+
 		// Set the correct content type based on the context
 		c.Response().Header.SetContentType(staller.GetContentType())
 
@@ -79,4 +80,3 @@ func (s *Server) Start() error {
 
 	return s.App.Listen(fmt.Sprintf("%s:%d", s.ListenHost, s.ListenPort))
 }
-


### PR DESCRIPTION
# What
Add new configuration option for IPV6 network stack support

# Why
So that go-pot can be used within ipv6 networks

# How
By allowing for the configuration of the internal fiber instance to use ipv6

# How to test:
Run `go run main.go start --host \[0:0:0:0:0:0:0:1\]  --network=tcp6` and visit `http://[::1]:8080/`

(Aims to resolve #1)