### PR TITLE
Add functionality to allow running behind a reverse proxy with correct IP logging

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -33,6 +33,12 @@ type (
 
 		// Network stack to use (tcp, tcp4, tcp6)
 		Network string `koanf:"network" validate:"required,oneof=tcp tcp4 tcp6"`
+
+		// The proxy header to use if the application is behind a proxy
+		ProxyHeader string `koanf:"proxy_header" validate:"omitempty"`
+
+		// The list of trusted proxies to use if the application is behind a proxy
+		TrustedProxies []string `koanf:"trusted_proxies" validate:"omitempty"`
 	}
 
 	// Cluster specific configuration

--- a/config/default.go
+++ b/config/default.go
@@ -5,9 +5,11 @@ import "go.uber.org/zap/zapcore"
 // Default configuration values for the application
 var defaultConfig = Config{
 	Server: serverConfig{
-		Port:    8080,
-		Host:    "127.0.0.1",
-		Network: "tcp4",
+		Port:           8080,
+		Host:           "127.0.0.1",
+		Network:        "tcp4",
+		ProxyHeader:    "",
+		TrustedProxies: []string{},
 	},
 	Logging: loggingConfig{
 		Level: zapcore.InfoLevel.String(),

--- a/http/server.go
+++ b/http/server.go
@@ -32,12 +32,18 @@ func NewServer(
 	logging logging.IServerLogger,
 	stallerFactory *stall.HttpStallerFactory,
 ) *Server {
+	// Only enable the trusted proxy check if we have trusted proxies
+	trustedProxyCheck := len(cfg.Server.TrustedProxies) > 0
 	server := &Server{
 		App: fiber.New(fiber.Config{
-			IdleTimeout:           time.Second * 15,
-			ReduceMemoryUsage:     true,
-			DisableStartupMessage: true,
-			Network:               cfg.Server.Network,
+			IdleTimeout:             time.Second * 15,
+			ReduceMemoryUsage:       true,
+			DisableStartupMessage:   true,
+			Network:                 cfg.Server.Network,
+			EnableIPValidation:      true,
+			ProxyHeader:             cfg.Server.ProxyHeader,
+			TrustedProxies:          cfg.Server.TrustedProxies,
+			EnableTrustedProxyCheck: trustedProxyCheck,
 		}),
 
 		ListenPort: cfg.Server.Port,


### PR DESCRIPTION
### What

This adds the necessary configuration for Fiber to run behind reverse proxy and log the correct IP address of the caller

### Why

Whenever someone is running this behind a reverse proxy, only the reverse proxies IP is logged. This is not very helpful for analytics.

### How

- [X] Added new configuration parameters (optional) to allow setting reverse proxy header and list of trusted proxies
- [X] Added the necessary configuration for Fiber to utilize this configuration and return the proper IP when calling ``` ctx.IP() ``` according to the documentation.

Small performance overhead gets generated by utilizing ``` EnableIPValidation ``` but this is a good way to ensure not returning spoofed, invalid IPs
 