### PR TITLE
FIX: Report filesize based on config over zero value

### DIFF
--- a/protocol/ftp/driver/file_info.go
+++ b/protocol/ftp/driver/file_info.go
@@ -22,7 +22,8 @@ type FtpFileInfo struct {
 
 func NewFtpFileInfo(path string, fileSize int) *FtpFileInfo {
 	return &FtpFileInfo{
-		path: path,
+		path:     path,
+		fileSize: fileSize,
 	}
 }
 


### PR DESCRIPTION
# What
Fixes filesize not being properly passed back to client machines